### PR TITLE
Update contact.md with <address> tag for postal address

### DIFF
--- a/content/contact.md
+++ b/content/contact.md
@@ -37,10 +37,11 @@ zz sina o pana sin e toki kepeken nimi pi ilo sin
 {% split %}
 {% en %}
 Our registered address: 
-
-1081-1249 RUE DU SUSSEX  
-MONTRÉAL QC  H3H 2A1  
-CANADA  
+<address> 
+1081-1249 RUE DU SUSSEX<br />  
+MONTRÉAL QC  H3H 2A1<br />  
+CANADA<br />  
+</address>
 {% enden %}
 
 {% sp %}


### PR DESCRIPTION
This edit adds [`<address>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/address) only for the Latin alphabet postal address. 

This edit does not add `<address>` for the sitelen pona address; if the sitelen pona address is supposed to be a postal address, I don't know what postal workers would recognize it.